### PR TITLE
refactor: use weak pointer with gfx instance

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -13,18 +13,6 @@ Chunk::Chunk(int index_x, int index_y) : index_x(index_x), index_y(index_y) {
   generate();
 }
 
-Chunk::~Chunk() {
-  for (auto const& tile : tiles) {
-    if (tile) {
-      Graphics::Instance()->remove(tile);
-    }
-  }
-
-  for (auto const& item : items) {
-    Graphics::Instance()->remove(item);
-  }
-}
-
 int Chunk::getXIndex() const {
   return index_x;
 }

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -26,7 +26,6 @@ class Chunk {
    * @param index_y - Chunk y index in chunk coordinates
    */
   Chunk(int index_x, int index_y);
-  ~Chunk();
 
   int getXIndex() const;
   int getYIndex() const;

--- a/src/Graphics.h
+++ b/src/Graphics.h
@@ -10,15 +10,19 @@
 #include "utility/Camera.h"
 
 struct SpriteCmp {
-  bool operator()(const std::shared_ptr<Sprite>& a,
-                  const std::shared_ptr<Sprite>& b) const {
-    if (a->getZ() != b->getZ()) {
-      return a->getZ() < b->getZ();
+  bool operator()(const std::weak_ptr<Sprite>& a,
+                  const std::weak_ptr<Sprite>& b) const {
+    if (a.expired() || b.expired()) {
+      return false;
     }
-    if (a->getPosition().y != b->getPosition().y) {
-      return a->getPosition().y < b->getPosition().y;
+
+    if (a.lock()->getZ() != b.lock()->getZ()) {
+      return a.lock()->getZ() < b.lock()->getZ();
     }
-    return a->getSpriteId() < b->getSpriteId();
+    if (a.lock()->getPosition().y != b.lock()->getPosition().y) {
+      return a.lock()->getPosition().y < b.lock()->getPosition().y;
+    }
+    return a.lock()->getSpriteId() < b.lock()->getSpriteId();
   }
 };
 
@@ -34,9 +38,12 @@ class Graphics {
   // Draw managed sprites
   void draw(const Camera& camera) const;
 
+  // Prune dead sprites
+  void prune();
+
  private:
   // Drawable
-  std::map<unsigned int, std::shared_ptr<Sprite>> sprites{};
+  std::map<unsigned int, std::weak_ptr<Sprite>> sprites{};
 
   bool needs_sorting = false;
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -5,6 +5,7 @@
 
 #include "Game.h"
 #include "GameMenu.h"
+#include "Graphics.h"
 #include "Menu.h"
 
 /*****************
@@ -20,6 +21,8 @@ void StateEngine::draw() {
 
 // Update
 void StateEngine::update() {
+  Graphics::Instance()->prune();
+
   if (state) {
     state->update(this);
   }


### PR DESCRIPTION
# Description
Remove shared pointers from graphics instance as they are mere observers of other sprites. Instead, call a cleanup routine that will prune dead sprites.